### PR TITLE
fix: add .ts extensions for ES module compatibility

### DIFF
--- a/lib/entity-resolver/cache.ts
+++ b/lib/entity-resolver/cache.ts
@@ -2,7 +2,7 @@
  * Session-aware entity caching
  */
 
-import { Entity } from "./types";
+import type { Entity } from "./types.ts";
 
 interface CacheEntry {
   entity: Entity;

--- a/lib/entity-resolver/index.ts
+++ b/lib/entity-resolver/index.ts
@@ -34,7 +34,7 @@ export {
   getEntityProfile,
   getAllEntityFacts,
   closeDbPool,
-} from "./resolver";
+} from "./resolver.ts";
 
 // Export cache functions
 export {
@@ -42,11 +42,11 @@ export {
   setCachedEntity,
   clearCache,
   getCacheStats,
-} from "./cache";
+} from "./cache.ts";
 
 // Export types
 export type {
   Entity,
   EntityFacts,
   EntityIdentifiers,
-} from "./types";
+} from "./types.ts";

--- a/lib/entity-resolver/resolver.ts
+++ b/lib/entity-resolver/resolver.ts
@@ -4,7 +4,7 @@
 
 import pg from "pg";
 import * as os from "os";
-import { Entity, EntityFacts, EntityIdentifiers, DbEntity, DbEntityFact } from "./types";
+import type { Entity, EntityFacts, EntityIdentifiers, DbEntity, DbEntityFact } from "./types.ts";
 
 const { Pool } = pg;
 

--- a/lib/entity-resolver/test.ts
+++ b/lib/entity-resolver/test.ts
@@ -19,7 +19,7 @@ import {
   clearCache,
   getCacheStats,
   closeDbPool,
-} from "./index";
+} from "./index.ts";
 
 async function test() {
   const identifier = process.argv[2];


### PR DESCRIPTION
Adds .ts extensions to import statements for ES module compatibility in entity-resolver components.